### PR TITLE
Fix mapbox-movement-public-sample-dataset v2 url

### DIFF
--- a/Notebooks/VirginiaNg-How-to-utilize-Mapbox-Movement-data-for-mobility-insights/airport_movement_aggregation.ipynb
+++ b/Notebooks/VirginiaNg-How-to-utilize-Mapbox-Movement-data-for-mobility-insights/airport_movement_aggregation.ipynb
@@ -84,7 +84,7 @@
     "from keplergl import KeplerGl\n",
     "\n",
     "# Download the sample CSV file consisting of January 1st, 2020 Movement data covering the San Francisco Bay Area.\n",
-    "movement_url = 'https://mapbox-movement-public-sample-dataset.s3.amazonaws.com/v0.2/daily-24h/v0.1.2/US/quadkey/total/2020/01/01/data/0230102.csv'\n",
+    "movement_url = 'https://mapbox-movement-public-sample-dataset.s3.amazonaws.com/v0.2/daily-24h/v2.0/US/quadkey/total/2020/01/01/data/0230102.csv'\n",
     "movement_df = download_csv_to_df(movement_url)\n",
     "\n",
     "# Rename a few columns for clarity:\n",


### PR DESCRIPTION
- Updates v1.02 url to v2.0
- Related: update same notebook that is stored in mapbox-movement-public-sample-dataset S3 bucket.