### PR TITLE
Update movement v2 data delimiter

### DIFF
--- a/Notebooks/VirginiaNg-How-to-utilize-Mapbox-Movement-data-for-mobility-insights/airport_movement_aggregation.ipynb
+++ b/Notebooks/VirginiaNg-How-to-utilize-Mapbox-Movement-data-for-mobility-insights/airport_movement_aggregation.ipynb
@@ -25,7 +25,7 @@
     "from io import StringIO\n",
     "import pandas as pd\n",
     "\n",
-    "def download_csv_to_df(url, parse_dates=False):\n",
+    "def download_csv_to_df(url, parse_dates=False, sep=\",\"):\n",
     "    \"\"\"\n",
     "    Given a url, downloads and reads the data to a Pandas DataFrame.\n",
     "    \n",
@@ -47,7 +47,7 @@
     "    except requests.exceptions.RequestException as e:\n",
     "        raise SystemExit(e)\n",
     "\n",
-    "    return pd.read_csv(StringIO(res.text), parse_dates=parse_dates)"
+    "    return pd.read_csv(StringIO(res.text), parse_dates=parse_dates, sep=sep)"
    ]
   },
   {
@@ -85,7 +85,7 @@
     "\n",
     "# Download the sample CSV file consisting of January 1st, 2020 Movement data covering the San Francisco Bay Area.\n",
     "movement_url = 'https://mapbox-movement-public-sample-dataset.s3.amazonaws.com/v0.2/daily-24h/v2.0/US/quadkey/total/2020/01/01/data/0230102.csv'\n",
-    "movement_df = download_csv_to_df(movement_url)\n",
+    "movement_df = download_csv_to_df(movement_url, sep=\"|\")\n",
     "\n",
     "# Rename a few columns for clarity:\n",
     "movement_df = movement_df.rename(\n",


### PR DESCRIPTION
@kuanb noticed that Movement v2 is using `|` as the delimiters instead of `,`. This PR updates `download_csv_to_df` so that it handles both types of delimiters:

- Movement v2:  `|`
- all other airport CSV files: `,`

 Thanks!